### PR TITLE
[Fix] 무한스크롤 관련 오류 해결

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <meta property="og:title" content="PRIMITIVE - 공주대학교 프로그래밍 동아리" />
   <meta property="og:description" content="공주대학교 프로그래밍 동아리 Primitive의 홈페이지입니다." />
   <meta property="og:image" content="/24/24PrimitiveLogoTransparent.png" />
-  <meta property="og:url" content="웹사이트 URL을 입력해주세요" />
+  <meta property="og:url" content="https://primitive.kr" />
   <meta property="og:site_name" content="PRIMITIVE" />
 
   <!-- Twitter Card Meta Tags -->

--- a/src/Pages/ProjectPage.tsx
+++ b/src/Pages/ProjectPage.tsx
@@ -21,7 +21,6 @@ import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ProjectDetail } from "../Types/ProjectType";
 import useStore from "../store";
 import { HiPencilSquare } from "react-icons/hi2";
-import Pagination from "../Components/Pagination";
 import LoadingCircle from "../Components/common/LoadingCircle";
 import ScrollToTop from "../Components/common/ScrollToTop";
 
@@ -49,6 +48,7 @@ const ProjectPage = () => {
   const [projectsLoading, setProjectsLoading] = useState(true);
   const [filter, setFilter] = useState<Filter>(isFilter(filterKind) ? filterKind : "default");
   const [tagFilter, setTagFilter] = useState("");
+  const [isLast, setIsLast] = useState(false);
 
   // 페이지네이션
   const [additionalLoading, setAdditionalLoading] = useState(false);
@@ -59,7 +59,7 @@ const ProjectPage = () => {
   };
   const observer = new IntersectionObserver(async (entries, observer) => {
     entries.forEach((entry) => {
-      if (entry.isIntersecting) {
+      if (entry.isIntersecting && !isLast) {
         setAdditionalLoading(true);
         getAdditionalProjects(isLoggedIn || false, lastDoc!);
         setAdditionalLoading(false);
@@ -119,6 +119,11 @@ const ProjectPage = () => {
             ...(doc.data() as Omit<ProjectDetail, "id">),
           }))
         );
+        if(response.docs.length < 12) {
+            setIsLast(true);
+        } else {
+            setIsLast(false);
+        }
         const lastDoc = response.docs[response.docs.length - 1];
         setLastDoc(lastDoc);
         setProjectsLoading(false);


### PR DESCRIPTION
가져와야하는 데이터 수가 페이지 1개의 최대 분량보다 적은데도 무한스크롤이 트리거 되는 현상 수정
